### PR TITLE
blueprint: Remove use of deprecated functions

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -14,11 +14,11 @@ function Mongo(nWorker) {
 
   const hostnames = this.containers.map(getHostname).join(',');
   this.containers.forEach((m) => {
-    m.setEnv('MEMBERS', hostnames);
+    m.env.MEMBERS = hostnames; // eslint-disable-line no-param-reassign
   });
 
   // The initiator is choosen completley arbitrarily.
-  this.containers[0].setEnv('INITIATOR', 'true');
+  this.containers[0].env.INITIATOR = 'true';
 
   allowTraffic(this.containers, this.containers, this.port);
 }

--- a/mongo.js
+++ b/mongo.js
@@ -9,7 +9,7 @@ function getHostname(c) {
 function Mongo(nWorker) {
   this.containers = [];
   for (let i = 0; i < nWorker; i += 1) {
-    this.containers.push(new Container('mongo', image));
+    this.containers.push(new Container({ name: 'mongo', image }));
   }
 
   const hostnames = this.containers.map(getHostname).join(',');

--- a/mongoExample.js
+++ b/mongoExample.js
@@ -11,5 +11,8 @@ const baseMachine = new Machine({
 
 const mongo = new Mongo(nWorker);
 
-const infra = new Infrastructure(baseMachine, baseMachine.replicate(nWorker));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(nWorker),
+});
 mongo.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.